### PR TITLE
updated schema, delete openapi

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "https://data.whop.com/api/v2/swagger_doc",
-  "openapi": "https://data.whop.com/api/v2/swagger_doc",
+  "$schema": "https://mintlify.com/schema.json",
   "name": "Whop Developers",
   "api": {
     "baseUrl": "https://api.whop.com/api",
@@ -68,10 +67,7 @@
     {
       "group": "Endpoint Examples",
       "pages": [
-        "api-reference/endpoint/get",
-        "api-reference/endpoint/create",
-        "api-reference/endpoint/update",
-        "api-reference/endpoint/delete"
+        "api-reference/dashboard-apicheckout-sessions/create-a-checkout-session"
       ]
     }
   ],


### PR DESCRIPTION
This PR changes the `mint.json` to update the schema and delete the `openapi` components and include a sample endpoint in the `API-Reference` section. 

![CleanShot 2023-08-11 at 13 14 42@2x](https://github.com/whopio/new-dev-docs/assets/123998500/c5eafc51-0a12-44d7-ab04-6e676ffb74d5)
