### PR TITLE
Fix npm command in examples

### DIFF
--- a/apps/examples/code-app.mdx
+++ b/apps/examples/code-app.mdx
@@ -336,7 +336,7 @@ pnpm whop-proxy
 ```
 
 ```bash npm
-npm whop-proxy
+npm run whop-proxy
 ```
 
 ```bash yarn

--- a/apps/examples/email-app.mdx
+++ b/apps/examples/email-app.mdx
@@ -198,7 +198,7 @@ pnpm whop-proxy
 ```
 
 ```bash npm
-npm whop-proxy
+npm run whop-proxy
 ```
 
 ```bash yarn

--- a/apps/examples/video-app.mdx
+++ b/apps/examples/video-app.mdx
@@ -307,7 +307,7 @@ pnpm whop-proxy
 ```
 
 ```bash npm
-npm whop-proxy
+npm run whop-proxy
 ```
 
 ```bash yarn

--- a/apps/examples/youtube-app.mdx
+++ b/apps/examples/youtube-app.mdx
@@ -301,7 +301,7 @@ pnpm whop-proxy
 ```
 
 ```bash npm
-npm whop-proxy
+npm run whop-proxy
 ```
 
 ```bash yarn


### PR DESCRIPTION
Update the command  "npm whop-proxy" to "npm run whop-proxy" in all examples